### PR TITLE
Fix altura iframe en historico

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -55,12 +55,15 @@ padding: 20px;
 border-radius: 0 0 10px 10px;
 } */
 
-.historic-container {
+.historic-container  {
   background-color: snow; /* Optional background color */
   padding: 20px; /* Optional padding for content inside the container */
   border-radius: 0 0 10px 10px;
   }
 
+.tradingview-widget-container iframe {
+  min-height: 50vh;
+}
 
 .price-container {
 


### PR DESCRIPTION
Agregando: 
.tradingview-widget-container iframe {
  min-height: 50vh;
}

para controlar la altura del contedor de trading view